### PR TITLE
Add separation as a valid parameter for the tree transform.

### DIFF
--- a/src/Tree.js
+++ b/src/Tree.js
@@ -25,6 +25,7 @@ Tree.Definition = {
   "params": [
     { "name": "field", "type": "field" },
     { "name": "sort", "type": "compare" },
+    { "name": "separation", "type": "function" },
     { "name": "method", "type": "enum", "default": "tidy", "values": ["tidy", "cluster"] },
     { "name": "size", "type": "number", "array": true, "length": 2 },
     { "name": "nodeSize", "type": "number", "array": true, "length": 2 },


### PR DESCRIPTION
- Resolves https://github.com/vega/vega/issues/1399

This will allow the tree transform to be called with a custom separation function which can return a separation value of 1 which will allow the leaf tree nodes that do not have a matching parent to be spaced the same as those which have a matching parent.   See - https://github.com/d3/d3-hierarchy/blob/master/README.md#tree_separation